### PR TITLE
Fix sequrity allerts

### DIFF
--- a/xom/frontend/app/static/Chart.js-ErrorBars-master/package.json
+++ b/xom/frontend/app/static/Chart.js-ErrorBars-master/package.json
@@ -27,7 +27,7 @@
     "inquirer": "^0.5.1",
     "jasmine": "^2.3.2",
     "jasmine-core": "^2.3.4",
-    "jquery": "^2.1.4",
+    "jquery": ">=3.5.0",
     "jshint-stylish": "~2.1.0",
     "karma": "^0.12.37",
     "karma-browserify": "^5.0.1",
@@ -37,7 +37,7 @@
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-html-reporter": "^0.1.8",
     "merge-stream": "^1.0.0",
-    "semver": "^3.0.1",
+    "semver": ">=4.3.2",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   },

--- a/xom/frontend/requirements.txt
+++ b/xom/frontend/requirements.txt
@@ -5,7 +5,7 @@ blinker==1.4
 bokeh==0.12.16
 cffi==1.11.5
 click==6.7
-cryptography==2.2.2
+cryptography>=3.2
 dominate==2.3.1
 Flask==0.12.2
 Flask-Bootstrap==3.3.7.1
@@ -19,7 +19,7 @@ Flask-WTF==0.14.2
 gunicorn==19.8.1
 idna==2.6
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2>=2.11.3
 Mako==1.0.7
 MarkupSafe==1.0
 numpy==1.14.5
@@ -32,10 +32,10 @@ pyparsing==2.2.0
 python-dateutil==2.7.2
 python-editor==1.0.3
 pytz==2018.4
-PyYAML==3.12
+PyYAML>=5.4 # pyyaml
 six==1.11.0
 SQLAlchemy==1.2.6
 tornado==5.0.2
 visitor==0.1.3
-Werkzeug==0.14.1
+werkzeug>=0.15.3
 WTForms==2.1


### PR DESCRIPTION
We should address these kind of alerts,
![afbeelding](https://user-images.githubusercontent.com/22295914/115667812-8d624d00-a346-11eb-98be-b117724d0594.png)

I'm not sure if this:
1. Will break anything
2. Affects working code (I'm not even sure if the XOM runs somewhere)

For more info, please checkout:
https://github.com/XENONnT/xom/security/dependabot

